### PR TITLE
Add checking stake approval before requesting approval to skip approval

### DIFF
--- a/apps/staking/hooks/registerNode.tsx
+++ b/apps/staking/hooks/registerNode.tsx
@@ -113,7 +113,7 @@ export default function useRegisterNode({
   const dictionary = useTranslations('actionModules.register.stage');
   const {
     approve,
-    writeStatus: approveWriteStatus,
+    status: approveWriteStatus,
     error: approveWriteError,
   } = useProxyApproval({
     // TODO: Create network provider to handle network specific logic

--- a/packages/contracts/hooks/SENT.tsx
+++ b/packages/contracts/hooks/SENT.tsx
@@ -152,6 +152,7 @@ export function useProxyApproval({
       }
       return;
     }
+    
     writeContract({
       args: [contractAddress, tokenAmount],
     });
@@ -165,6 +166,7 @@ export function useProxyApproval({
     if (!hasEnoughAllowance) {
       return writeStatus;
     }
+
     if (readStatus === CONTRACT_READ_STATUS.PENDING) {
       return 'idle';
     } else {

--- a/packages/contracts/hooks/SENT.tsx
+++ b/packages/contracts/hooks/SENT.tsx
@@ -5,6 +5,7 @@ import { useAccount } from 'wagmi';
 import { ReadContractData } from 'wagmi/query';
 import { SENTAbi } from '../abis';
 import {
+  CONTRACT_READ_STATUS,
   ContractReadQueryFetchOptions,
   ReadContractQuery,
   useContractReadQuery,
@@ -12,6 +13,9 @@ import {
 } from './contract-hooks';
 import type { WriteContractErrorType } from 'wagmi/actions';
 import type { ContractWriteStatus } from './ServiceNodeRewards';
+import { CHAIN, chains } from '../chains';
+import { useEffect, useMemo, useState } from 'react';
+import { isProduction } from '@session/util/env';
 
 export type SENTBalanceQuery = ReadContractQuery & {
   /** Get the session token balance */
@@ -20,11 +24,12 @@ export type SENTBalanceQuery = ReadContractQuery & {
   balance: ReadContractData<typeof SENTAbi, 'balanceOf', [Address]>;
 };
 
-export function useSENTBalanceQuery(
-  props?: ContractReadQueryFetchOptions<
-    ContractFunctionArgs<typeof SENTAbi, 'pure' | 'view', 'balanceOf'>
-  >
-): SENTBalanceQuery {
+export function useSENTBalanceQuery({
+  chainId,
+  startEnabled,
+}: ContractReadQueryFetchOptions<
+  ContractFunctionArgs<typeof SENTAbi, 'pure' | 'view', 'balanceOf'>
+>): SENTBalanceQuery {
   const { address } = useAccount();
   const {
     data: balance,
@@ -34,8 +39,9 @@ export function useSENTBalanceQuery(
   } = useContractReadQuery({
     contract: 'SENT',
     functionName: 'balanceOf',
-    startEnabled: (props?.startEnabled ?? false) && Boolean(address),
+    startEnabled: startEnabled && !!address,
     args: address ? [address] : undefined,
+    chainId,
   });
 
   const getBalance = () => {
@@ -53,9 +59,54 @@ export function useSENTBalanceQuery(
   };
 }
 
+export type SENTAllowanceQuery = ReadContractQuery & {
+  /** Get the session token allowance */
+  getAllowance: () => void;
+  /** The session token allowance for a contract */
+  allowance: ReadContractData<typeof SENTAbi, 'allowance', [Address, Address]>;
+};
+
+export function useAllowanceQuery({
+  contractAddress,
+  chainId,
+}: Omit<
+  ContractReadQueryFetchOptions<ContractFunctionArgs<typeof SENTAbi, 'pure' | 'view', 'allowance'>>,
+  'startEnabled' | 'args'
+> & { contractAddress: Address }): SENTAllowanceQuery {
+  const { address } = useAccount();
+  const {
+    data: allowance,
+    readContract,
+    throwError,
+    ...rest
+  } = useContractReadQuery({
+    contract: 'SENT',
+    functionName: 'allowance',
+    chainId: chainId,
+  });
+
+  const getAllowance = () => {
+    if (!address) {
+      throwError(new Error('Address is required to get balance'));
+      return;
+    }
+    if (!contractAddress) {
+      throwError(new Error('Contract Address is required to get allowance'));
+      return;
+    }
+    readContract({ args: [address, contractAddress] });
+  };
+
+  return {
+    allowance,
+    getAllowance,
+    ...rest,
+  };
+}
+
 export type UseProxyApprovalReturn = {
   approve: () => void;
-  writeStatus: ContractWriteStatus;
+  status: ContractWriteStatus;
   error: WriteContractErrorType | Error | null;
 };
 
@@ -66,16 +117,66 @@ export function useProxyApproval({
   contractAddress: Address;
   tokenAmount: bigint;
 }): UseProxyApprovalReturn {
+  const [hasEnoughAllowance, setHasEnoughAllowance] = useState<boolean>(false);
+  const { address } = useAccount();
+  const {
+    allowance,
+    getAllowance,
+    status: readStatus,
+  } = useAllowanceQuery({
+    contractAddress,
+    chainId: chains[CHAIN.TESTNET].id,
+  });
+
   const { writeContract, error, writeStatus } = useContractWriteQuery({
     contract: 'SENT',
     functionName: 'approve',
+    chainId: chains[CHAIN.TESTNET].id,
   });
 
   const approve = () => {
+    getAllowance();
+  };
+
+  const approveWrite = () => {
+    if (readStatus !== CONTRACT_READ_STATUS.SUCCESS) {
+      throw new Error('Checking if current allowance is sufficient');
+    }
+
+    if (allowance >= tokenAmount) {
+      setHasEnoughAllowance(true);
+      if (!isProduction()) {
+        console.debug(
+          `Allowance for ${address} on contract ${contractAddress} is sufficient: ${allowance}`
+        );
+      }
+      return;
+    }
     writeContract({
       args: [contractAddress, tokenAmount],
     });
   };
 
-  return { approve, writeStatus, error };
+  const status = useMemo(() => {
+    if (readStatus === CONTRACT_READ_STATUS.SUCCESS && hasEnoughAllowance) {
+      return 'success';
+    }
+
+    if (!hasEnoughAllowance) {
+      return writeStatus;
+    }
+    if (readStatus === CONTRACT_READ_STATUS.PENDING) {
+      return 'idle';
+    } else {
+      return writeStatus;
+    }
+  }, [readStatus, writeStatus, hasEnoughAllowance]);
+
+  useEffect(() => {
+    if (readStatus === CONTRACT_READ_STATUS.SUCCESS) {
+      approveWrite();
+    }
+  }, [allowance, readStatus]);
+
+  return { approve, status, error };
 }

--- a/packages/contracts/hooks/contract-hooks.tsx
+++ b/packages/contracts/hooks/contract-hooks.tsx
@@ -91,7 +91,6 @@ export type ReadContractQuery = ContractQuery & {
   isSuccess: boolean;
   /** The status of the read contract */
   status: CONTRACT_READ_STATUS;
-
   refetch: (
     options?: RefetchOptions | undefined
   ) => Promise<QueryObserverResult<unknown, ReadContractErrorType>>;
@@ -115,6 +114,11 @@ export type GenericContractReadQuery<Args, Data> = ReadContractQuery & {
   data: Data;
 };
 
+export type ContractWriteQueryFetchOptions = {
+  /** Chain id the contract is on */
+  chainId: number;
+};
+
 export function useContractWriteQuery<
   T extends ContractName,
   C extends ContractAbis[T],
@@ -123,10 +127,11 @@ export function useContractWriteQuery<
 >({
   contract,
   functionName,
+  chainId,
 }: {
   contract: T;
   functionName: FName;
-}): GenericContractWriteQuery<Args> {
+} & ContractWriteQueryFetchOptions): GenericContractWriteQuery<Args> {
   const [internalError, setInternalError] = useState<Error | null>(null);
   const {
     writeContract: write,
@@ -162,7 +167,7 @@ export function useContractWriteQuery<
       setInternalError(new Error('Failed to get contract address'));
       return;
     } */
-    /* 
+    /*
     if (Array.isArray(args)) {
       const missingArgs: Array<number> = [];
       args.forEach((arg, index) => {
@@ -182,6 +187,7 @@ export function useContractWriteQuery<
       abi: abi as Abi,
       functionName: functionName,
       args: args as ContractFunctionArgs,
+      chainId,
     });
   };
 
@@ -203,6 +209,8 @@ export type ContractReadQueryFetchOptions<Args = unknown> = {
   startEnabled?: boolean;
   /** The initial arguments to use when fetching the contract. */
   args?: Args;
+  /** Chain id the contract is on */
+  chainId: number;
 };
 
 export function useContractReadQuery<
@@ -216,6 +224,7 @@ export function useContractReadQuery<
   functionName,
   startEnabled = false,
   args: initialArgs,
+  chainId,
 }: {
   contract: T;
   functionName: FName;
@@ -243,6 +252,7 @@ export function useContractReadQuery<
     abi: abi as Abi,
     functionName: functionName,
     args: args as ContractFunctionArgs,
+    chainId,
   });
 
   const readContract: WriteContractFunction<Args> = ({ args }) => {


### PR DESCRIPTION
When registering a session node, the operator must approve the rewards contract to take the required stake amount, this only needs to be done once. This change adds a check to the registration stages to see if the operator as already approved the required stake amount.